### PR TITLE
closing open file after  use

### DIFF
--- a/PP0/StaticClasses/OperationsWithJson.cs
+++ b/PP0/StaticClasses/OperationsWithJson.cs
@@ -13,7 +13,7 @@ namespace PP0.StaticClasses
         private static readonly JsonSerializerOptions _options = new() { WriteIndented = true };
 
         internal static List<T> DeserilizeJson<T>(string fileName) {
-            Stream streamJson = new FileStream(fileName,FileMode.Open,FileAccess.Read);
+            using Stream streamJson = new FileStream(fileName,FileMode.Open,FileAccess.Read);
             return JsonSerializer.Deserialize<List<T>>(streamJson, _options);
         }
 


### PR DESCRIPTION
"using Stream streamJson" -zamknięcie klauzulą using eliminuje błąd, zajętego pliku przez inny proces przy kolejnej próbie rejestracji (przy ponownym uruchomieniu aplikacji). Tak jakoś dziwnie u mnie to się działo, że przy pierwszym uruchomieniu aplikacji rejestracja działała i mogłem dodawać wielu użytkowników, ale ponowne uruchomienie aplikacji potrafiło rzucić błędem na starcie.